### PR TITLE
Combine single-item and multi-item channels

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -2053,6 +2053,9 @@ workflow {
         .groupTuple()
         .set { bams_to_merge }
 
+    check_sample_sheet.out.log_piece1.view()
+    logs_to_combine.view()
+
     // Combine logs
     combine_logs(
         check_sample_sheet.out.log_piece1,

--- a/main.nf
+++ b/main.nf
@@ -508,8 +508,7 @@ process combine_logs {
     cache 'lenient'
 
     input:
-        file log_piece1
-        tuple val(key), path(log_piece2), path(log_piece3), path(log_piece4)
+        tuple path(log_piece1), val(key), path(log_piece2), path(log_piece3), path(log_piece4)
 
     output:
         tuple val(key), path("*_pre.log"), emit: "log_premerge"
@@ -2053,13 +2052,12 @@ workflow {
         .groupTuple()
         .set { bams_to_merge }
 
-    check_sample_sheet.out.log_piece1.view()
-    logs_to_combine.view()
-
     // Combine logs
     combine_logs(
-        check_sample_sheet.out.log_piece1,
-        logs_to_combine
+        check_sample_sheet
+            .out
+            .log_piece1
+            .combine(logs_to_combine)
     )
 
     // Merge BAMs


### PR DESCRIPTION
`check_sample_sheet.out.log_piece1` only contained 1 item, but `logs_to_combine` contained many. Using `.combine()` is the best way to ensure that the downstream process runs for every item in `logs_to_combine`